### PR TITLE
fix: save delivery_fee with order and update Chowdeck buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the Satellite Kitchen website will be documented in this 
 ## [Unreleased]
 
 ### Added
+- **Delivery Fee Persistence**
+  - Added `delivery_fee` column to Orders table (numeric)
+  - Updated `/api/bank-transfer/create-order` to save delivery_fee from cart
+  - Updated Cart page to pass delivery_fee when creating orders
+  - Updated Admin Verify Orders page to display saved delivery_fee
+  - Created SQL migration: `migrations/20260314_add_delivery_fee.sql`
+
+### Changed
+- **Order Buttons Updated**
+  - Changed "Order on WhatsApp" → "Order on Chowdeck" in footer and nav
+  - Updated link to Chowdeck store: `https://store.chowdeck.com/amuwo-odofin-1/restaurants/satellite-kitchen9pt53j`
+  - Added `target="_blank" rel="noopener noreferrer"` for security
+
+### Added
 - **Chowdeck Delivery Integration**
   - New API route `/api/delivery/quote` - POST endpoint to get delivery fee quotes from Chowdeck
     - Accepts: pickup_address, delivery_address, items

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Button } from "@/components/ui/button"
-import { FaPhoneAlt, FaWhatsapp } from "react-icons/fa";
+import { FaPhoneAlt } from "react-icons/fa";
+import { MdDeliveryDining } from "react-icons/md";
 import Link from 'next/link';
 
 export default function Footer() {
@@ -12,7 +13,7 @@ export default function Footer() {
                     <p className="my-2 font-medium">Proud to serve</p>
                     <p className="my-2">contact@satellitekitchen.ng</p>
                     <p className="my-2 flex items-center gap-2"> <FaPhoneAlt /> <span>+234 08034746311</span></p>
-                    <a href={`https://api.whatsapp.com/send?phone=2347032189083&text=Hello%2C%20I%20would%20like%20to%20make%20an%20order`} target="_blank" rel="noopener noreferrer"> <Button className="bg-primary-green px-8 py-6 text-base my-3"><FaWhatsapp size={25} className="mx-2" /> Order on Whatsapp</Button></a>
+                    <a href="https://store.chowdeck.com/amuwo-odofin-1/restaurants/satellite-kitchen9pt53j" target="_blank" rel="noopener noreferrer"> <Button className="bg-primary-green px-8 py-6 text-base my-3"><MdDeliveryDining size={25} className="mx-2" /> Order on Chowdeck</Button></a>
                 </div>
                 <div className="w-full md:w-3/12">
                     <ul>

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -1,4 +1,4 @@
-import { FaWhatsapp } from "react-icons/fa";
+import { MdDeliveryDining } from "react-icons/md";
 import { Button } from "./ui/button";
 import { IoIosClose, IoIosMenu } from "react-icons/io";
 import { useEffect, useState } from "react";
@@ -187,7 +187,7 @@ export default function Nav() {
                                 </Link>
                             </li>
                             <li className="my-8 hover:underline hover:text-primary cursor-pointer" onClick={() => setMenuOpen(false)}><Link href="/my-orders">My Orders</Link></li>
-                            <li className="my-8" onClick={() => setMenuOpen(false)}><a href={`https://api.whatsapp.com/send?phone=2347032189083&text=Hello%2C%20I%20would%20like%20to%20make%20an%20order`} target="_blank" rel="noopener noreferrer"><Button className="bg-primary-green px-4 py-6 text-base my-3"><FaWhatsapp size={25} className="mx-2" /> Order on Whatsapp</Button></a></li>
+                            <li className="my-8" onClick={() => setMenuOpen(false)}><a href="https://store.chowdeck.com/amuwo-odofin-1/restaurants/satellite-kitchen9pt53j" target="_blank" rel="noopener noreferrer"><Button className="bg-primary-green px-4 py-6 text-base my-3"><MdDeliveryDining size={25} className="mx-2" /> Order on Chowdeck</Button></a></li>
                             {!loading && (
                                 <li className="my-8">
                                     {user ? (

--- a/migrations/20260314_add_delivery_fee.sql
+++ b/migrations/20260314_add_delivery_fee.sql
@@ -1,0 +1,9 @@
+-- Migration: Add delivery_fee column to Orders table
+-- Created: 2026-03-14
+
+-- Add delivery_fee column for storing Chowdeck delivery fee
+ALTER TABLE "Orders" 
+ADD COLUMN IF NOT EXISTS delivery_fee NUMERIC;
+
+-- Add comment to document the new field
+COMMENT ON COLUMN "Orders".delivery_fee IS 'Delivery fee charged by Chowdeck for this order';

--- a/pages/admin/verify-orders.tsx
+++ b/pages/admin/verify-orders.tsx
@@ -26,6 +26,7 @@ type OrderRow = {
     delivery_status?: DeliveryStatus | null;
     delivery_tracking?: DeliveryStatus | null;
     delivery_address?: string | null;
+    delivery_fee?: number | null;
     delivery_instructions?: string | null;
     vendor_instructions?: string | null;
     bank_receipt_url?: string | null;
@@ -534,6 +535,9 @@ export default function VerifyOrdersPage() {
                                 <p><span className="text-gray-500">Method:</span> {order.payment_method || 'N/A'}</p>
                                 <p><span className="text-gray-500">Reference:</span> {order.payment_reference || 'N/A'}</p>
                                 <p><span className="text-gray-500">Status:</span> {order.payment_status ? '✅ Paid' : '⏳ Pending'}</p>
+                                {order.delivery_fee !== null && order.delivery_fee !== undefined && (
+                                    <p><span className="text-gray-500">Delivery Fee:</span> {formatCurrency(order.delivery_fee)}</p>
+                                )}
                                 {order.paid_at && <p><span className="text-gray-500">Paid At:</span> {new Date(order.paid_at).toLocaleString()}</p>}
                                 {order.confirmed_at && <p><span className="text-gray-500">Confirmed At:</span> {new Date(order.confirmed_at).toLocaleString()}</p>}
                             </div>

--- a/pages/api/bank-transfer/create-order.ts
+++ b/pages/api/bank-transfer/create-order.ts
@@ -11,6 +11,7 @@ type InitiateBankTransferBody = {
     deliveryAddress?: string;
     deliveryInstructions?: string;
     vendorInstructions?: string;
+    deliveryFee?: number;
     items?: unknown;
 };
 
@@ -64,6 +65,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             delivery_address: body.deliveryAddress?.trim() || null,
             delivery_instructions: body.deliveryInstructions?.trim() || null,
             vendor_instructions: body.vendorInstructions?.trim() || null,
+            delivery_fee: body.deliveryFee ?? null,
             delivery_status: "preparing" as const,
             order_notes: {
                 items: trustedItems,

--- a/pages/cart/index.tsx
+++ b/pages/cart/index.tsx
@@ -519,6 +519,7 @@ export default function CartPage() {
                         deliveryAddress: defaultAddressLine,
                         deliveryInstructions,
                         vendorInstructions,
+                        deliveryFee: deliveryQuote?.available ? deliveryQuote.delivery_fee : 0,
                         items: items.map((item) => ({
                             id: item.productRef || item.id,
                             quantity: item.quantity,

--- a/types_db.ts
+++ b/types_db.ts
@@ -91,6 +91,7 @@ export type Database = {
           confirmed_by: string | null
           created_at: string
           delivery_address: string | null
+          delivery_fee: number | null
           delivery_id: string | null
           delivery_instructions: string | null
           delivery_status: Database["public"]["Enums"]["Delivery_status"] | null
@@ -114,6 +115,7 @@ export type Database = {
           confirmed_by?: string | null
           created_at?: string
           delivery_address?: string | null
+          delivery_fee?: number | null
           delivery_id?: string | null
           delivery_instructions?: string | null
           delivery_status?: Database["public"]["Enums"]["Delivery_status"] | null
@@ -137,6 +139,7 @@ export type Database = {
           confirmed_by?: string | null
           created_at?: string
           delivery_address?: string | null
+          delivery_fee?: number | null
           delivery_id?: string | null
           delivery_instructions?: string | null
           delivery_status?: Database["public"]["Enums"]["Delivery_status"] | null


### PR DESCRIPTION
- Add delivery_fee column to Orders table (numeric)
- Update /api/bank-transfer/create-order to save delivery_fee from cart
- Update cart page to pass delivery_fee when creating orders
- Update verify-orders page to display saved delivery_fee
- Change 'Order on WhatsApp' → 'Order on Chowdeck' in footer and nav
- Update link to Chowdeck store with target='_blank' rel='noopener noreferrer'
- Update types_db.ts to include delivery_fee in Orders table
- Create SQL migration: migrations/20260314_add_delivery_fee.sql
- Update CHANGELOG.md